### PR TITLE
Fix syntax error on php >=5.6

### DIFF
--- a/libs/class-setting-page.php
+++ b/libs/class-setting-page.php
@@ -60,7 +60,8 @@ class WpOgp_SettingPage
 			}
 		}
 
-		$this->_sections[$id] =& new WpOgp_SettingSection($this->_id, $id, $title, $callback);
+		$section = new WpOgp_SettingSection($this->_id, $id, $title, $callback);
+		$this->_sections[$id] =& $section;
 
 		return $this->_sections[$id];
 	}

--- a/libs/class-setting-section.php
+++ b/libs/class-setting-section.php
@@ -41,7 +41,8 @@ class WpOgp_SettingSection
 
 	function &createField($id, $title = null, $type = null, $options = array())
 	{
-		$this->_fields[$id] =& new WpOgp_SettingField($this->_page, $this->_id, $id, $title);
+		$field = new WpOgp_SettingField($this->_page, $this->_id, $id, $title);
+		$this->_fields[$id] =& $field;
 
 		if ($type) {
 			$this->_fields[$id]->createForm($id, $type, $options);


### PR DESCRIPTION
素晴らしいプラグインをありがとうございます！便利に使わせていただいております。

PHP 5.6以上の環境だと、 `=& new` が以下のとおりsyntax errorになるため、修正いたしました。
マージしていただけましたらタグ付けもお願いできますとありがたいです。

```
Parse error: syntax error, unexpected 'new' (T_NEW) in /path/to/project/wp-content/plugins/wp-ogp-customized/libs/class-setting-page.php on line 63
```